### PR TITLE
Update to 2018.1.2 and add VM definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A very simple vagrant environment for getting up and running with Puppet Enterprise. 
 
-This repo provides you with a complete, yet simple environment that consists of a master (CentOS7), as well as a Linux (CentOS7) and Windows VM.
+This repo provides you with a complete, yet simple environment that consists of a master (CentOS7), as well as a Linux (CentOS7) and Windows VM. It's been updated to add a VM running Gitlab and a separate VM for use as a replica in an HA configuration.
 
-Shout out to Grace Andrews for putting this together! I have updated this fork to use Puppet Enterprise 2017.3.5.
+Shout out to Grace Andrews for putting this together! I have updated this fork to use Puppet Enterprise 2018.1.2.
 
 ## Pre-Steps ##
 
@@ -26,6 +26,10 @@ Once both are installed, you'll be able to do the following steps from your CLI:
 'vagrant up /linux/'
 
 'vagrant up /windows/'
+
+'vagrant up /gitlab/'
+
+'vagrant up /replica/'
 
 'vagrant hosts list'
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,4 +31,25 @@ Vagrant.configure("2") do |config|
       v.memory = 2048
     end
   end
+
+  config.vm.define "replica.vm" do |replica|
+    replica.vm.box = "centos/7"
+    replica.vm.hostname = "replica.vm"
+    replica.vm.network "private_network", ip: "192.168.50.7"
+    replica.vm.provision "shell", path: "scripts/replica.sh"
+    replica.vm.provider "virtualbox" do |v|
+      v.memory = 2048
+    end
+  end
+
+  config.vm.define "gitlab.vm" do |gitlab|
+    gitlab.vm.box = "centos/7"
+    gitlab.vm.hostname = "gitlab.vm"
+    gitlab.vm.network "private_network", ip: "192.168.50.8"
+    gitlab.vm.provision "shell", path: "scripts/linux_gitlab.sh"
+    gitlab.vm.provider "virtualbox" do |v|
+      v.memory = 2048
+    end
+  end
+
 end

--- a/scripts/linux_gitlab.sh
+++ b/scripts/linux_gitlab.sh
@@ -1,0 +1,10 @@
+#/bin/bash
+set -ex
+hostname gitlab.vm
+echo '192.168.50.4 master.vm master' >> /etc/hosts
+echo '192.168.50.8 gitlab.vm linux' >> /etc/hosts
+curl -k https://master.vm:8140/packages/current/install.bash | bash
+curl -s https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/script.rpm.sh | sudo bash
+yum -y install gitlab-ce
+sed -i 's/gitlab.example.com/gitlab.vm/g' /etc/gitlab/gitlab.rb
+sudo gitlab-ctl reconfigure

--- a/scripts/masterbootstrap.sh
+++ b/scripts/masterbootstrap.sh
@@ -4,7 +4,7 @@ hostname master.vm
 echo '192.168.50.4 master.vm master' >> /etc/hosts
 mkdir -p /etc/puppetlabs/puppet
 echo '*' > /etc/puppetlabs/puppet/autosign.conf
-curl -Lo pe.archive 'https://pm.puppetlabs.com/puppet-enterprise/2017.3.5/puppet-enterprise-2017.3.5-el-7-x86_64.tar.gz'  
+curl -Lo pe.archive 'https://pm.puppetlabs.com/puppet-enterprise/2018.1.2/puppet-enterprise-2018.1.2-el-7-x86_64.tar.gz'  
 tar -xf pe.archive
 cat > pe.conf <<-EOF
 {

--- a/scripts/replica.sh
+++ b/scripts/replica.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+hostname replica.vm
+echo '192.168.50.4 master.vm master' >> /etc/hosts
+echo '192.168.50.7 replica.vm replica' >> /etc/hosts
+curl -k https://master.vm:8140/packages/current/install.bash | bash


### PR DESCRIPTION
Hi,

I've been using your fork and have added to it, time to give back.  :)

Updated the PE version to 2018.1.2 and added two Guests, one for a Gitlab instance which includes a script that installs Gitlab and configures it, and one designed to be used as a replica for testing HA configuration.