### PR TITLE
Remove ignored app orchestration setting from pe.conf

### DIFF
--- a/scripts/masterbootstrap.sh
+++ b/scripts/masterbootstrap.sh
@@ -10,7 +10,6 @@ cat > pe.conf <<-EOF
 {
   "console_admin_password": "puppetlabs"
   "puppet_enterprise::puppet_master_host": "%{::trusted.certname}"
-  "puppet_enterprise::use_application_services": true
   "puppet_enterprise::profile::master::check_for_updates": false
 }
 EOF


### PR DESCRIPTION
In version 2016.4 we started to issue deprecations for this setting.  In 2016.4
and subsequent releases, it's completely ignored.